### PR TITLE
feat: add toggle activation mode for layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ mode = "off"                # off / mouse / joystick
 # Hold LM for gyro aim + full mouse mode
 [layer.aim]
 trigger = "LM"              # trigger button: A/B/X/Y/LB/RB/LT/RT/M1-M4/LM/RM/C/Z
-tap = "mouse_side"          # tap action: KEY_*, mouse_left/right/middle/side/extra
-hold_timeout = 200          # ms before layer activates
+activation = "hold"         # hold (default) or toggle
+tap = "mouse_side"          # tap action (hold mode): KEY_*, mouse_left/right/middle/side/extra
+hold_timeout = 200          # ms before layer activates (hold mode)
 gyro = { mode = "mouse", sensitivity = 2.0 }
 stick_left = { mode = "scroll" }   # mode: gamepad / mouse / scroll
 stick_right = { mode = "mouse", sensitivity = 1.0 }  # mode: gamepad / mouse
@@ -91,6 +92,12 @@ trigger = "RM"
 stick_right = { mode = "mouse", sensitivity = 1.5 }
 dpad = { mode = "arrows" }
 remap = { A = "mouse_left", B = "mouse_right" }
+
+# Toggle M1: tap to enable gyro, tap again to disable
+[layer.gyro_toggle]
+trigger = "M1"
+activation = "toggle"
+gyro = { mode = "mouse", sensitivity = 1.5 }
 ```
 
 See [docs/configuration.md](docs/configuration.md) for full options.

--- a/config/test-toggle.toml
+++ b/config/test-toggle.toml
@@ -1,0 +1,19 @@
+emulate_elite = true
+
+[gyro]
+mode = "off"
+
+# Toggle mode: tap M1 to activate gyro, tap again to deactivate
+[layer.gyro_toggle]
+trigger = "C"
+activation = "toggle"
+gyro = { mode = "mouse", sensitivity = 2.0, smoothing = 0.3 }
+
+# Hold mode for comparison: hold LM for mouse mode
+[layer.aim]
+trigger = "LM"
+activation = "hold"
+tap = "KEY_TAB"
+hold_timeout = 200
+gyro = { mode = "mouse", sensitivity = 1.5 }
+stick_right = { mode = "mouse", sensitivity = 1.0 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,8 +51,9 @@ Hold a trigger button to activate a layer. Release to return to base mode.
 ```toml
 [layer.name]
 trigger = "LM"            # which button activates this layer
-tap = "KEY_TAB"           # optional: key to send on quick tap
-hold_timeout = 200        # ms before layer activates (for tap-hold)
+activation = "hold"       # hold (default) or toggle
+tap = "KEY_TAB"           # optional: key to send on quick tap (hold mode only)
+hold_timeout = 200        # ms before layer activates (hold mode only)
 
 # Override settings while layer is active
 gyro = { mode = "mouse", sensitivity = 2.0 }
@@ -68,7 +69,14 @@ remap = { RB = "mouse_left", RT = "mouse_right", A = "KEY_SPACE" }
 
 Available triggers: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `M1`, `M2`, `M3`, `M4`, `LM`, `RM`, `C`, `Z`
 
-### Tap-Hold Behavior
+### Activation Modes
+
+| Mode | Behavior |
+|------|----------|
+| `hold` | Hold trigger to activate, release to deactivate (default) |
+| `toggle` | Tap trigger once to activate, tap again to deactivate |
+
+### Tap-Hold Behavior (hold mode only)
 
 When `tap` is set:
 - Quick press + release (< hold_timeout) = send tap key
@@ -150,6 +158,12 @@ hold_timeout = 150
 stick_right = { mode = "mouse", sensitivity = 1.5 }
 dpad = { mode = "arrows" }
 remap = { A = "mouse_left", B = "mouse_right" }
+
+# Toggle M1: gyro always on until toggled off
+[layer.gyro_toggle]
+trigger = "M1"
+activation = "toggle"
+gyro = { mode = "mouse", sensitivity = 1.5 }
 ```
 
 ## Key Codes Reference

--- a/include/vader5/config.hpp
+++ b/include/vader5/config.hpp
@@ -41,10 +41,12 @@ struct DpadConfig {
 };
 
 struct LayerConfig {
+    enum Activation { Hold, Toggle };
     std::string name;
     std::string trigger;
     std::optional<RemapTarget> tap;
     int hold_timeout{200};
+    Activation activation{Hold};
 
     std::optional<GyroConfig> gyro;
     std::optional<StickConfig> stick_left;

--- a/include/vader5/gamepad.hpp
+++ b/include/vader5/gamepad.hpp
@@ -5,6 +5,7 @@
 #include "uinput.hpp"
 
 #include <chrono>
+#include <unordered_set>
 
 namespace vader5 {
 
@@ -42,6 +43,7 @@ class Gamepad {
     void process_layer_buttons(const GamepadState& state, const GamepadState& prev);
     void process_base_remaps(const GamepadState& state, const GamepadState& prev);
     void update_tap_hold(const GamepadState& state, const GamepadState& prev);
+    void emit_tap(const RemapTarget& tap);
     auto get_active_layer() -> const LayerConfig*;
     static auto is_button_pressed(const GamepadState& state, std::string_view name) -> bool;
 
@@ -56,6 +58,7 @@ class Gamepad {
     Config config_;
     GamepadState prev_state_{};
     std::unordered_map<std::string, TapHoldState> tap_hold_states_;
+    std::unordered_set<std::string> toggled_layers_;
     float gyro_vel_x_{0.0F};
     float gyro_vel_y_{0.0F};
     float gyro_accum_x_{0.0F};

--- a/openspec/changes/tap-to-activate/proposal.md
+++ b/openspec/changes/tap-to-activate/proposal.md
@@ -1,0 +1,11 @@
+# Tap-to-Activate Layer Mode
+
+## Why
+
+Current layer activation requires holding the trigger button. Toggle mode allows tap to activate/deactivate, freeing the trigger finger.
+
+## What Changes
+
+- Add `activation = "toggle"` option to layer config
+- Tap trigger once to activate layer, tap again to deactivate
+- Maintain backward compatibility with default hold behavior

--- a/openspec/changes/tap-to-activate/specs/remap-system/spec.md
+++ b/openspec/changes/tap-to-activate/specs/remap-system/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Toggle Activation Mode
+
+The driver SHALL support toggle activation mode for layers, where tap activates and tap again deactivates.
+
+#### Scenario: Toggle layer on
+- **WHEN** layer contains `activation = "toggle"`
+- **AND** trigger button is tapped
+- **THEN** layer activates and remains active after release
+
+#### Scenario: Toggle layer off
+- **WHEN** toggle layer is active
+- **AND** trigger button is tapped again
+- **THEN** layer deactivates
+
+#### Scenario: Toggle mode single-layer constraint
+- **WHEN** toggle layer is active
+- **AND** another layer trigger is pressed
+- **THEN** second layer does NOT activate

--- a/openspec/changes/tap-to-activate/tasks.md
+++ b/openspec/changes/tap-to-activate/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+1. [x] Add `Activation` enum to `LayerConfig` in config.hpp
+2. [x] Add `toggled_layers_` set to `Gamepad` in gamepad.hpp
+3. [x] Parse `activation` field in config.cpp
+4. [x] Implement toggle logic in gamepad.cpp
+5. [x] Update docs/configuration.md
+6. [x] Build passes with clang-tidy

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -98,6 +98,9 @@ auto parse_layer(const std::string& name, const toml::table& tbl) -> LayerConfig
     if (const auto* val = tbl["hold_timeout"].as_integer()) {
         layer.hold_timeout = static_cast<int>(val->get());
     }
+    if (const auto* val = tbl["activation"].as_string()) {
+        layer.activation = (val->get() == "toggle") ? LayerConfig::Toggle : LayerConfig::Hold;
+    }
     if (const auto* sub = tbl["gyro"].as_table()) {
         GyroConfig gc;
         parse_gyro(*sub, gc);


### PR DESCRIPTION
## Summary

- Add `activation = "toggle"` option for layers
- Tap trigger once to activate layer, tap again to deactivate
- Maintains backward compatibility (default is `hold` mode)

## Changes

- `LayerConfig::Activation` enum (Hold/Toggle)
- `toggled_layers_` set in Gamepad class
- Config parsing for `activation` field
- Toggle logic in `update_tap_hold()`
- Updated README and docs/configuration.md

## Test

```toml
[layer.gyro_toggle]
trigger = "M1"
activation = "toggle"
gyro = { mode = "mouse", sensitivity = 1.5 }
```

Tap M1 to enable gyro, tap again to disable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced toggle activation mode for layers - tap once to enable, tap again to disable
  * Added explicit activation configuration field to layers (hold mode by default)

* **Documentation**
  * Clarified that tap behavior applies only in hold activation mode
  * Updated configuration documentation with examples for both hold and toggle layer activation modes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->