### PR TITLE
fix: use correct VID/PID when emulate_elite is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,3 +66,12 @@ add_executable(test-remap
 set_target_properties(test-remap PROPERTIES CXX_CLANG_TIDY "")
 target_include_directories(test-remap PRIVATE include)
 target_link_libraries(test-remap PRIVATE tomlplusplus::tomlplusplus)
+
+add_executable(test-uinput-elite
+    src/tools/test_uinput_elite.cpp
+    src/config.cpp
+    src/keycodes.cpp
+)
+set_target_properties(test-uinput-elite PROPERTIES CXX_CLANG_TIDY "")
+target_include_directories(test-uinput-elite PRIVATE include)
+target_link_libraries(test-uinput-elite PRIVATE tomlplusplus::tomlplusplus)

--- a/config/test-elite-default.toml
+++ b/config/test-elite-default.toml
@@ -1,0 +1,2 @@
+[gyro]
+mode = "off"

--- a/config/test-elite-false.toml
+++ b/config/test-elite-false.toml
@@ -1,0 +1,4 @@
+emulate_elite = false
+
+[gyro]
+mode = "off"

--- a/config/test-elite-true.toml
+++ b/config/test-elite-true.toml
@@ -1,0 +1,4 @@
+emulate_elite = true
+
+[gyro]
+mode = "off"

--- a/include/vader5/uinput.hpp
+++ b/include/vader5/uinput.hpp
@@ -20,6 +20,7 @@ struct RumbleEffect {
 class Uinput {
   public:
     static auto create(std::span<const std::optional<int>> ext_mappings,
+                       bool emulate_elite = true,
                        const char* name = "Vader 5 Pro Virtual Gamepad") -> Result<Uinput>;
     ~Uinput();
 

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -216,7 +216,7 @@ auto Gamepad::open(const Config& cfg, const std::string& device_name) -> Result<
         return std::unexpected(std::make_error_code(std::errc::protocol_error));
     }
 
-    auto uinput = Uinput::create(cfg.ext_mappings);
+    auto uinput = Uinput::create(cfg.ext_mappings, cfg.emulate_elite);
     if (!uinput) {
         send_test_mode(*hid, false);
         return std::unexpected(uinput.error());

--- a/src/tools/test_uinput_elite.cpp
+++ b/src/tools/test_uinput_elite.cpp
@@ -1,0 +1,44 @@
+#include "vader5/config.hpp"
+#include "vader5/types.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+using namespace vader5;
+
+#define CHECK(expr)                                                                                \
+    do {                                                                                           \
+        if (!(expr)) {                                                                             \
+            std::cerr << "FAIL: " #expr " (" << __FILE__ << ":" << __LINE__ << ")\n";              \
+            std::exit(1);                                                                          \
+        }                                                                                          \
+    } while (0)
+
+void test_config_emulate_elite_default() {
+    auto cfg = Config::load("config/test-elite-default.toml");
+    CHECK(cfg.has_value());
+    CHECK(cfg->emulate_elite == true);
+    std::cout << "  emulate_elite default (absent): OK\n";
+}
+
+void test_config_emulate_elite_true() {
+    auto cfg = Config::load("config/test-elite-true.toml");
+    CHECK(cfg.has_value());
+    CHECK(cfg->emulate_elite == true);
+    std::cout << "  emulate_elite = true: OK\n";
+}
+
+void test_config_emulate_elite_false() {
+    auto cfg = Config::load("config/test-elite-false.toml");
+    CHECK(cfg.has_value());
+    CHECK(cfg->emulate_elite == false);
+    std::cout << "  emulate_elite = false: OK\n";
+}
+
+int main() {
+    std::cout << "Running uinput elite emulation tests...\n";
+    test_config_emulate_elite_default();
+    test_config_emulate_elite_true();
+    test_config_emulate_elite_false();
+    std::cout << "All tests passed!\n";
+}

--- a/src/uinput.cpp
+++ b/src/uinput.cpp
@@ -61,7 +61,7 @@ inline void InputDevice::buffer_event(const input_event& ev) {
 }
 
 auto Uinput::create(std::span<const std::optional<int>> ext_mappings,
-                    const char* name) -> Result<Uinput> {
+                    bool emulate_elite, const char* name) -> Result<Uinput> {
     const int file_descriptor = ::open("/dev/uinput", O_RDWR | O_NONBLOCK);
     if (file_descriptor < 0) {
         int err = errno;
@@ -132,8 +132,8 @@ auto Uinput::create(std::span<const std::optional<int>> ext_mappings,
     std::strncpy(setup.name, name, UINPUT_MAX_NAME_SIZE - 1);
     setup.name[UINPUT_MAX_NAME_SIZE - 1] = '\0';
     setup.id.bustype = BUS_USB;
-    setup.id.vendor = ELITE_VENDOR_ID;
-    setup.id.product = ELITE_PRODUCT_ID;
+    setup.id.vendor = emulate_elite ? ELITE_VENDOR_ID : VENDOR_ID;
+    setup.id.product = emulate_elite ? ELITE_PRODUCT_ID : PRODUCT_ID;
     setup.id.version = 1;
     setup.ff_effects_max = 16;
 


### PR DESCRIPTION
## Summary
- Pass `emulate_elite` flag to `Uinput::create()` so the virtual gamepad uses standard VID/PID (0x37d7:0x2401) instead of Xbox Elite (0x045e:0x0b00) when `emulate_elite = false`
- Previously, the virtual device always identified as Xbox Elite regardless of config

## Changes
- `include/vader5/uinput.hpp`: Add `bool emulate_elite` parameter to `Uinput::create()`
- `src/uinput.cpp`: Select VID/PID based on `emulate_elite` flag
- `src/gamepad.cpp`: Pass `cfg.emulate_elite` to `Uinput::create()`
- `src/tools/test_uinput_elite.cpp`: Test suite for config parsing of emulate_elite
- `config/test-elite-{default,true,false}.toml`: Test configs

## Test plan
- [x] `test-uinput-elite` passes — verifies config parsing for all 3 cases (absent/true/false)
- [x] `test-remap` passes — no regressions
- [ ] Manual: set `emulate_elite = false`, verify Steam no longer shows Xbox Elite

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Elite mode emulation support for the virtual gamepad, enabling configuration of device identifiers. When enabled, the device reports as an Elite variant; when disabled, it reports as a standard gamepad.

* **Tests**
  * Added comprehensive test coverage for Elite mode configuration, validating behavior across default, enabled, and disabled scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->