### PR TITLE
fix: auto-detect hidraw input interface in debug tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,12 @@ add_executable(vader5-debug
 target_include_directories(vader5-debug PRIVATE include)
 target_link_libraries(vader5-debug PRIVATE ftxui::screen ftxui::dom ftxui::component)
 
+add_executable(test-debug-iface
+    src/tools/test_debug_iface.cpp
+)
+set_target_properties(test-debug-iface PROPERTIES CXX_CLANG_TIDY "")
+target_include_directories(test-debug-iface PRIVATE include)
+
 add_executable(test-remap
     src/tools/test_remap.cpp
     src/config.cpp

--- a/include/vader5/debug_options.hpp
+++ b/include/vader5/debug_options.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace vader5 {
+
+struct DebugOptions {
+    int input_iface{-1};  // -1 = auto-detect
+    int config_iface{1};
+
+    static auto parse(int argc, const char* const* argv) -> DebugOptions {
+        DebugOptions opts;
+        for (int i = 1; i < argc; ++i) {
+            std::string arg(argv[i]);
+            try {
+                if (arg == "--input" && i + 1 < argc) {
+                    opts.input_iface = std::stoi(argv[++i]);
+                } else if (arg == "--config" && i + 1 < argc) {
+                    opts.config_iface = std::stoi(argv[++i]);
+                }
+            } catch (const std::exception&) {
+                std::cerr << "Invalid value for " << arg << "\n";
+                std::exit(1);
+            }
+        }
+        return opts;
+    }
+};
+
+} // namespace vader5

--- a/src/tools/debug.cpp
+++ b/src/tools/debug.cpp
@@ -1,3 +1,4 @@
+#include "vader5/debug_options.hpp"
 #include "vader5/hidraw.hpp"
 #include "vader5/types.hpp"
 
@@ -40,8 +41,10 @@ using ftxui::WIDTH;
 
 constexpr size_t READ_BUFFER_SIZE = 32;
 constexpr int READ_TIMEOUT_MS = 16;
-constexpr uint8_t IFACE_INPUT = 0;
-constexpr uint8_t IFACE_CONFIG = 1;
+constexpr size_t REPORT_24G_SIZE = 20;
+constexpr uint8_t SUBTYPE_24G = 0x14;
+constexpr int DETECT_ATTEMPTS = 50;
+constexpr int DETECT_INTERVAL_MS = 5;
 constexpr int TRIGGER_BAR_WIDTH = 15;
 
 constexpr uint8_t MAGIC_5A = 0x5a;
@@ -510,37 +513,69 @@ void config_thread(vader5::Hidraw& hidraw_cfg) {
     }
 }
 
-auto open_hidraw_input() -> std::optional<vader5::Hidraw> {
-    auto hidraw = vader5::Hidraw::open(vader5::VENDOR_ID, vader5::PRODUCT_ID, IFACE_INPUT);
+auto find_input_interface() -> std::optional<int> {
+    for (int iface : {0, 2, 3}) {
+        auto hid = vader5::Hidraw::open(vader5::VENDOR_ID, vader5::PRODUCT_ID, iface);
+        if (!hid) {
+            continue;
+        }
+        std::array<uint8_t, READ_BUFFER_SIZE> buf{};
+        for (int attempt = 0; attempt < DETECT_ATTEMPTS; ++attempt) {
+            auto bytes = hid->read(buf);
+            if (bytes && *bytes == REPORT_24G_SIZE && buf[1] == SUBTYPE_24G) {
+                return iface;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(DETECT_INTERVAL_MS));
+        }
+    }
+    return std::nullopt;
+}
+
+auto open_hidraw_input(int iface) -> std::optional<vader5::Hidraw> {
+    auto hidraw = vader5::Hidraw::open(vader5::VENDOR_ID, vader5::PRODUCT_ID, iface);
     if (!hidraw) {
-        std::cerr << "Error: Failed to open hidraw (Interface 0)\n";
+        std::cerr << "Error: Failed to open hidraw (Interface " << iface << ")\n";
         return std::nullopt;
     }
-    std::cerr << "Hidraw opened (Interface 0)\n";
-    add_log("IF0: hidraw OK");
+    std::cerr << "Hidraw opened (Interface " << iface << ")\n";
+    add_log("IF" + std::to_string(iface) + ": hidraw OK");
     return std::move(*hidraw);
 }
 
-auto open_hidraw_config() -> std::optional<vader5::Hidraw> {
-    auto hidraw_cfg = vader5::Hidraw::open(vader5::VENDOR_ID, vader5::PRODUCT_ID, IFACE_CONFIG);
+auto open_hidraw_config(int iface) -> std::optional<vader5::Hidraw> {
+    auto hidraw_cfg = vader5::Hidraw::open(vader5::VENDOR_ID, vader5::PRODUCT_ID, iface);
     if (!hidraw_cfg) {
-        std::cerr << "Warning: Failed to open hidraw (Interface 1)\n";
-        add_log("IF1: hidraw FAILED");
+        std::cerr << "Warning: Failed to open hidraw (Interface " << iface << ")\n";
+        add_log("IF" + std::to_string(iface) + ": hidraw FAILED");
         return std::nullopt;
     }
-    std::cerr << "Hidraw opened (Interface 1)\n";
-    add_log("IF1: hidraw OK");
+    std::cerr << "Hidraw opened (Interface " << iface << ")\n";
+    add_log("IF" + std::to_string(iface) + ": hidraw OK");
     return std::move(*hidraw_cfg);
 }
 } // namespace
 
-auto main() -> int {
-    auto hidraw_input = open_hidraw_input();
+auto main(int argc, char* argv[]) -> int {
+    auto opts = vader5::DebugOptions::parse(argc, argv);
+
+    int input_iface = opts.input_iface;
+    if (input_iface < 0) {
+        std::cerr << "Auto-detecting input interface...\n";
+        auto detected = find_input_interface();
+        if (!detected) {
+            std::cerr << "Error: no valid input interface found. Use --input N to specify.\n";
+            return EXIT_FAILURE;
+        }
+        input_iface = *detected;
+        std::cerr << "Using input interface: " << input_iface << "\n";
+    }
+
+    auto hidraw_input = open_hidraw_input(input_iface);
     if (!hidraw_input) {
         return EXIT_FAILURE;
     }
 
-    auto hidraw_cfg = open_hidraw_config();
+    auto hidraw_cfg = open_hidraw_config(opts.config_iface);
 
     std::optional<std::thread> cfg_handler;
     if (hidraw_cfg) {

--- a/src/tools/test_debug_iface.cpp
+++ b/src/tools/test_debug_iface.cpp
@@ -1,0 +1,56 @@
+#include "vader5/debug_options.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+#define CHECK(expr) do { if (!(expr)) { std::cerr << "FAIL: " #expr " (" << __FILE__ << ":" << __LINE__ << ")\n"; std::exit(1); } } while (0)
+
+void test_cli_parse_defaults() {
+    const char* args[] = {"vader5-debug"};
+    auto opts = vader5::DebugOptions::parse(1, args);
+    CHECK(opts.input_iface == -1);
+    CHECK(opts.config_iface == 1);
+    std::cout << "  cli parse defaults: OK\n";
+}
+
+void test_cli_parse_input_override() {
+    const char* args[] = {"vader5-debug", "--input", "2"};
+    auto opts = vader5::DebugOptions::parse(3, args);
+    CHECK(opts.input_iface == 2);
+    CHECK(opts.config_iface == 1);
+    std::cout << "  cli parse input override: OK\n";
+}
+
+void test_cli_parse_config_override() {
+    const char* args[] = {"vader5-debug", "--config", "3"};
+    auto opts = vader5::DebugOptions::parse(3, args);
+    CHECK(opts.input_iface == -1);
+    CHECK(opts.config_iface == 3);
+    std::cout << "  cli parse config override: OK\n";
+}
+
+void test_cli_parse_both_override() {
+    const char* args[] = {"vader5-debug", "--input", "2", "--config", "1"};
+    auto opts = vader5::DebugOptions::parse(5, args);
+    CHECK(opts.input_iface == 2);
+    CHECK(opts.config_iface == 1);
+    std::cout << "  cli parse both override: OK\n";
+}
+
+void test_cli_parse_unknown_ignored() {
+    const char* args[] = {"vader5-debug", "--foo", "bar"};
+    auto opts = vader5::DebugOptions::parse(3, args);
+    CHECK(opts.input_iface == -1);
+    CHECK(opts.config_iface == 1);
+    std::cout << "  cli parse unknown ignored: OK\n";
+}
+
+int main() {
+    std::cout << "Running debug interface tests...\n";
+    test_cli_parse_defaults();
+    test_cli_parse_input_override();
+    test_cli_parse_config_override();
+    test_cli_parse_both_override();
+    test_cli_parse_unknown_ignored();
+    std::cout << "All tests passed!\n";
+}


### PR DESCRIPTION
## Summary
- Debug tool now auto-detects the correct input interface instead of hardcoding interface 0
- Adds `--input N` and `--config N` CLI args for manual override
- Returns clear error if no valid input interface is found

## Changes
- `include/vader5/debug_options.hpp`: CLI argument parsing with input validation
- `src/tools/debug.cpp`: Replace hardcoded `IFACE_INPUT=0` with auto-detection; probe interfaces 0,2,3 for valid HID reports
- `src/tools/test_debug_iface.cpp`: Test suite for CLI argument parsing
- `CMakeLists.txt`: Add test target

## Test plan
- [x] `test-debug-iface` passes — verifies CLI parsing (defaults, overrides, unknown args)
- [ ] Manual: run `vader5-debug` with a controller on a non-standard interface
- [ ] Manual: run `vader5-debug --input 2` to verify CLI override

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Debug tool now supports command-line options (`--input`, `--config`) for explicit interface selection.
  * Added automatic detection of input interfaces for improved usability.
  * Enhanced runtime interface configuration parsing and handling.

* **Tests**
  * Added comprehensive test suite validating debug interface options and configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->