### PR TITLE
remove add action so the driver kicks in on boot

### DIFF
--- a/install/99-vader5-systemd.rules
+++ b/install/99-vader5-systemd.rules
@@ -1,4 +1,4 @@
 # Populate envs on hidraw device; we can't match in the later rule with attrs on two different parent devices.
-ACTION=="add", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="37d7", ATTRS{idProduct}=="2401", IMPORT{builtin}="usb_id"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="37d7", ATTRS{idProduct}=="2401", IMPORT{builtin}="usb_id"
 # Expose config interface to systemd
-ACTION=="add", SUBSYSTEM=="hidraw", ENV{ID_VENDOR_ID}=="37d7", ENV{ID_MODEL_ID}=="2401", ATTRS{bInterfaceNumber}=="01", TAG+="systemd", ENV{SYSTEMD_WANTS}+="vader5d@%k.service"
+SUBSYSTEM=="hidraw", ENV{ID_VENDOR_ID}=="37d7", ENV{ID_MODEL_ID}=="2401", ATTRS{bInterfaceNumber}=="01", TAG+="systemd", ENV{SYSTEMD_WANTS}+="vader5d@%k.service"


### PR DESCRIPTION
- Allows the system to populate envs and expose the config on boot if the controller is plugged in.
- Remove need to unplug-replug dongle after booting up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated device detection rules for HID raw devices to ensure consistent application across initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->