### PR TITLE
fix: tap mapped to gamepad button not firing

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -324,11 +324,8 @@ auto Gamepad::get_active_layer() -> const LayerConfig* {
 
 void Gamepad::emit_tap(const RemapTarget& tap) {
     if (tap.type == RemapTarget::GamepadButton) {
-        auto press = prev_state_;
-        press.buttons |= tap.btn_mask;
-        press.ext_buttons |= tap.ext_mask;
-        [[maybe_unused]] auto r1 = uinput_.emit(press, prev_state_);
-        [[maybe_unused]] auto r2 = uinput_.emit(prev_state_, press);
+        injected_buttons_ |= tap.btn_mask;
+        injected_ext_ |= tap.ext_mask;
         return;
     }
     if (!input_) {


### PR DESCRIPTION
## Summary
- Fix gamepad button taps being invisible to state-polling applications (SDL, XInput)
- Replace synchronous press+release in `emit_tap` with the existing `injected_buttons_`/`injected_ext_` injection mechanism so the button persists for one full HID poll period

Closes #25