### PR TITLE
feat: add optional hidapi backend for CONFIG_HIDRAW=n environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ set(FTXUI_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(tomlplusplus ftxui)
 
+# ---- Options ----
+
 option(ENABLE_CLANG_TIDY "Enable clang-tidy" ON)
+option(USE_HIDAPI "Use hidapi (libusb backend) instead of Linux hidraw" OFF)
 
 if(ENABLE_CLANG_TIDY)
     find_program(CLANG_TIDY clang-tidy)
@@ -39,24 +42,60 @@ endif()
 
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
+# ---- Backend selection ----
+
+if(USE_HIDAPI)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(HIDAPI REQUIRED hidapi-libusb)
+    add_compile_definitions(VADER5_USE_HIDAPI)
+
+    set(HIDRAW_SOURCES src/hidapi_device.cpp)
+    set(HIDRAW_LIBS ${HIDAPI_LIBRARIES})
+    set(HIDRAW_INCLUDE_DIRS ${HIDAPI_INCLUDE_DIRS})
+    set(HIDRAW_LIBRARY_DIRS ${HIDAPI_LIBRARY_DIRS})
+    set(HIDRAW_CFLAGS ${HIDAPI_CFLAGS_OTHER})
+
+    message(STATUS "Using hidapi (libusb) backend for HID communication")
+    message(STATUS "  hidapi include: ${HIDAPI_INCLUDE_DIRS}")
+    message(STATUS "  hidapi libs:    ${HIDAPI_LIBRARIES}")
+else()
+    set(HIDRAW_SOURCES src/hidraw.cpp)
+    set(HIDRAW_LIBS "")
+    set(HIDRAW_INCLUDE_DIRS "")
+    set(HIDRAW_LIBRARY_DIRS "")
+    set(HIDRAW_CFLAGS "")
+
+    message(STATUS "Using Linux hidraw backend for HID communication")
+endif()
+
+# ---- Targets ----
+
+# vader5d daemon
 add_executable(vader5d
     src/daemon/main.cpp
-    src/hidraw.cpp
+    ${HIDRAW_SOURCES}
     src/uinput.cpp
     src/gamepad.cpp
     src/config.cpp
     src/keycodes.cpp
     src/mouse.cpp
 )
-target_include_directories(vader5d PRIVATE include)
-target_link_libraries(vader5d PRIVATE tomlplusplus::tomlplusplus)
+target_include_directories(vader5d PRIVATE include ${HIDRAW_INCLUDE_DIRS})
+target_link_libraries(vader5d PRIVATE tomlplusplus::tomlplusplus ${HIDRAW_LIBS})
+target_link_directories(vader5d PRIVATE ${HIDRAW_LIBRARY_DIRS})
+target_compile_options(vader5d PRIVATE ${HIDRAW_CFLAGS})
 
+# vader5-debug TUI tool
 add_executable(vader5-debug
     src/tools/debug.cpp
-    src/hidraw.cpp
+    ${HIDRAW_SOURCES}
 )
-target_include_directories(vader5-debug PRIVATE include)
-target_link_libraries(vader5-debug PRIVATE ftxui::screen ftxui::dom ftxui::component)
+target_include_directories(vader5-debug PRIVATE include ${HIDRAW_INCLUDE_DIRS})
+target_link_libraries(vader5-debug PRIVATE ftxui::screen ftxui::dom ftxui::component ${HIDRAW_LIBS})
+target_link_directories(vader5-debug PRIVATE ${HIDRAW_LIBRARY_DIRS})
+target_compile_options(vader5-debug PRIVATE ${HIDRAW_CFLAGS})
+
+# ---- Test targets ----
 
 add_executable(test-debug-iface
     src/tools/test_debug_iface.cpp

--- a/include/vader5/gamepad.hpp
+++ b/include/vader5/gamepad.hpp
@@ -55,6 +55,9 @@ class Gamepad {
     auto poll() -> Result<void>;
     void poll_ff();
     auto send_rumble(uint8_t left, uint8_t right) -> bool;
+    auto reconnect_hid() -> Result<void> {
+        return hidraw_.reconnect(VENDOR_ID, PRODUCT_ID, 2);
+    }
     [[nodiscard]] auto fd() const noexcept -> int {
         return hidraw_.fd();
     }

--- a/include/vader5/hidraw.hpp
+++ b/include/vader5/hidraw.hpp
@@ -6,6 +6,9 @@
 #include <span>
 #include <string>
 
+// Forward declaration
+struct hid_device_;
+
 namespace vader5 {
 
 class Hidraw {
@@ -18,8 +21,10 @@ class Hidraw {
     Hidraw(const Hidraw&) = delete;
     auto operator=(const Hidraw&) -> Hidraw& = delete;
 
+    // Returns a dummy fd for compatibility. The real I/O goes through hidapi.
+    // This fd should NOT be used for read/write/poll - only for existence checks.
     [[nodiscard]] auto fd() const noexcept -> int {
-        return fd_;
+        return device_ ? 0 : -1;
     }
     [[nodiscard]] auto phys() const -> Result<std::string>;
     [[nodiscard]] auto read(std::span<uint8_t> buf) const -> Result<size_t>;
@@ -28,8 +33,8 @@ class Hidraw {
         -> std::optional<GamepadState>;
 
   private:
-    explicit Hidraw(int file_descriptor) : fd_(file_descriptor) {}
-    int fd_{-1};
+    explicit Hidraw(struct hid_device_* device) : device_(device) {}
+    struct hid_device_* device_{nullptr};
 
     [[nodiscard]] static auto parse_report_24g(std::span<const uint8_t> data)
         -> std::optional<GamepadState>;

--- a/include/vader5/hidraw.hpp
+++ b/include/vader5/hidraw.hpp
@@ -15,6 +15,7 @@ class Hidraw {
   public:
     static auto open(uint16_t vid, uint16_t pid, int iface = 0, const std::string& device_name = "") -> Result<Hidraw>;
     ~Hidraw();
+    auto reconnect(uint16_t vid, uint16_t pid, int iface = 0) -> Result<void>;
 
     Hidraw(Hidraw&& other) noexcept;
     auto operator=(Hidraw&& other) noexcept -> Hidraw&;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -10,6 +10,8 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <span>
 #include <thread>
 
@@ -84,15 +86,19 @@ auto main(int argc, char* argv[]) -> int {
     timerfd_settime(timer_fd, 0, &timer_spec, nullptr);
 #endif
 
-    while (g_running.load(std::memory_order_relaxed)) {
-        auto gamepad = vader5::Gamepad::open(cfg, device_name);
-        if (!gamepad) {
+    // Create gamepad once to keep uinput device stable across reconnections
+    std::unique_ptr<vader5::Gamepad> gamepad;
+    while (g_running.load(std::memory_order_relaxed) && !gamepad) {
+        auto gp = vader5::Gamepad::open(cfg, device_name);
+        if (gp) {
+            gamepad = std::make_unique<vader5::Gamepad>(std::move(*gp));
+            std::cout << "vader5d: Device connected, running..." << std::endl;
+        } else {
             std::this_thread::sleep_for(RETRY_INTERVAL);
-            continue;
         }
+    }
 
-        std::cout << "vader5d: Device connected, running...\n";
-
+    while (g_running.load(std::memory_order_relaxed) && gamepad) {
 #ifdef VADER5_USE_HIDAPI
         // ---- hidapi backend ----
         int ff_fd = gamepad->ff_fd();
@@ -107,7 +113,7 @@ auto main(int argc, char* argv[]) -> int {
                 if (ec == std::errc::resource_unavailable_try_again) {
                     // No data available, normal
                 } else if (ec == std::errc::no_such_device || ec == std::errc::io_error) {
-                    std::cout << "vader5d: Device disconnected\n";
+                    std::cout << "vader5d: Device disconnected, reconnecting...\n";
                     break;
                 } else {
                     std::cerr << "vader5d: Read error: " << ec.message() << "\n";
@@ -143,6 +149,19 @@ auto main(int argc, char* argv[]) -> int {
             }
         }
         sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+
+        // Reconnect hidapi while keeping uinput alive
+        if (g_running.load(std::memory_order_relaxed)) {
+            std::cout << "vader5d: Waiting for device to reconnect...\n";
+            while (g_running.load(std::memory_order_relaxed)) {
+                auto rc = gamepad->reconnect_hid();
+                if (rc) {
+                    std::cout << "vader5d: Device reconnected, running...\n";
+                    break;
+                }
+                std::this_thread::sleep_for(RETRY_INTERVAL);
+            }
+        }
 #else
         // ---- hidraw backend (original) ----
         std::array<pollfd, 2> pfds{{
@@ -189,9 +208,23 @@ auto main(int argc, char* argv[]) -> int {
             }
         }
         sigprocmask(SIG_SETMASK, &old_mask, nullptr);
-#endif
 
-        std::cout << "vader5d: Waiting for reconnection...\n";
+        // hidraw backend: reconnect gamepad (destroys and recreates uinput)
+        if (g_running.load(std::memory_order_relaxed)) {
+            std::cout << "vader5d: Waiting for device to reconnect...\n";
+            // Gamepad destructor will destroy uinput; loop restarts from top
+            gamepad.reset();
+            while (g_running.load(std::memory_order_relaxed) && !gamepad) {
+                auto gp = vader5::Gamepad::open(cfg, device_name);
+                if (gp) {
+                    gamepad = std::make_unique<vader5::Gamepad>(std::move(*gp));
+                    std::cout << "vader5d: Device reconnected, running...\n";
+                } else {
+                    std::this_thread::sleep_for(RETRY_INTERVAL);
+                }
+            }
+        }
+#endif
     }
 
 #ifdef VADER5_USE_HIDAPI

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -15,6 +15,11 @@
 
 #include <poll.h>
 
+#ifdef VADER5_USE_HIDAPI
+#include <sys/timerfd.h>
+#include <unistd.h>
+#endif
+
 namespace {
 std::atomic<bool> g_running{true};
 
@@ -64,6 +69,21 @@ auto main(int argc, char* argv[]) -> int {
     sigaddset(&block_mask, SIGTERM);
     sigaddset(&block_mask, SIGINT);
 
+#ifdef VADER5_USE_HIDAPI
+    // Timerfd-based polling loop: hidapi does not expose a pollable fd,
+    // so we use a 1ms timerfd to wake the loop periodically and call
+    // hid_read_timeout() which internally does its own short timeout.
+    int timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
+    if (timer_fd < 0) {
+        std::cerr << "vader5d: Failed to create timerfd: " << std::strerror(errno) << "\n";
+        return 1;
+    }
+    itimerspec timer_spec{};
+    timer_spec.it_value.tv_nsec = 1000000;     // 1ms initial
+    timer_spec.it_interval.tv_nsec = 1000000;  // 1ms periodic
+    timerfd_settime(timer_fd, 0, &timer_spec, nullptr);
+#endif
+
     while (g_running.load(std::memory_order_relaxed)) {
         auto gamepad = vader5::Gamepad::open(cfg, device_name);
         if (!gamepad) {
@@ -72,13 +92,64 @@ auto main(int argc, char* argv[]) -> int {
         }
 
         std::cout << "vader5d: Device connected, running...\n";
+
+#ifdef VADER5_USE_HIDAPI
+        // ---- hidapi backend ----
+        int ff_fd = gamepad->ff_fd();
+
+        sigset_t old_mask;
+        sigprocmask(SIG_BLOCK, &block_mask, &old_mask);
+
+        while (g_running.load(std::memory_order_relaxed)) {
+            auto result = gamepad->poll();
+            if (!result) {
+                auto ec = result.error();
+                if (ec == std::errc::resource_unavailable_try_again) {
+                    // No data available, normal
+                } else if (ec == std::errc::no_such_device || ec == std::errc::io_error) {
+                    std::cout << "vader5d: Device disconnected\n";
+                    break;
+                } else {
+                    std::cerr << "vader5d: Read error: " << ec.message() << "\n";
+                }
+            }
+
+            gamepad->poll_ff();
+
+            std::array<pollfd, 2> pfds{};
+            pfds[0].fd = timer_fd;
+            pfds[0].events = POLLIN;
+            int nfds = 1;
+
+            if (ff_fd >= 0) {
+                pfds[1].fd = ff_fd;
+                pfds[1].events = POLLIN;
+                nfds = 2;
+            }
+
+            const int ret = ppoll(pfds.data(), nfds, nullptr, &empty_mask);
+            if (ret < 0) {
+                const int err = errno;
+                if (err == EINTR) {
+                    continue;
+                }
+                std::cerr << "vader5d: poll error: " << std::strerror(err) << "\n";
+                break;
+            }
+
+            if (pfds[0].revents & POLLIN) {
+                uint64_t expirations;
+                ::read(timer_fd, &expirations, sizeof(expirations));
+            }
+        }
+        sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+#else
+        // ---- hidraw backend (original) ----
         std::array<pollfd, 2> pfds{{
             {.fd = gamepad->fd(), .events = POLLIN, .revents = 0},
             {.fd = gamepad->ff_fd(), .events = POLLIN, .revents = 0},
         }};
 
-        // Block signals except when we're polling, which allows an indefinite poll without a race
-        // where we may miss a signal
         sigset_t old_mask;
         sigprocmask(SIG_BLOCK, &block_mask, &old_mask);
 
@@ -118,10 +189,14 @@ auto main(int argc, char* argv[]) -> int {
             }
         }
         sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+#endif
 
         std::cout << "vader5d: Waiting for reconnection...\n";
     }
 
+#ifdef VADER5_USE_HIDAPI
+    ::close(timer_fd);
+#endif
     std::cout << "vader5d: Shutting down\n";
     return 0;
 }

--- a/src/hidapi_device.cpp
+++ b/src/hidapi_device.cpp
@@ -1,0 +1,184 @@
+#include "vader5/hidraw.hpp"
+#include "vader5/protocol.hpp"
+
+#ifdef VADER5_USE_HIDAPI
+
+#include <hidapi.h>
+
+#include <climits>
+#include <cstring>
+#include <utility>
+
+namespace vader5 {
+
+constexpr uint8_t DPAD_MASK = 0x0F;
+
+auto find_hidraw_device(uint16_t vid, uint16_t pid, int iface_num) -> Result<std::string> {
+    // hidapi-libusb returns paths like "0003:37D7:2401.0003" for interface 3
+    struct hid_device_info* devs = hid_enumerate(vid, pid);
+    struct hid_device_info* cur = devs;
+    std::string result_path;
+    while (cur) {
+        if (iface_num < 0 || cur->interface_number == iface_num) {
+            result_path = cur->path;
+            break;
+        }
+        cur = cur->next;
+    }
+    hid_free_enumeration(devs);
+
+    if (result_path.empty()) {
+        return std::unexpected(std::make_error_code(std::errc::no_such_device));
+    }
+    return result_path;
+}
+
+auto Hidraw::open(uint16_t vid, uint16_t pid, int iface,
+                  const std::string& device_name) -> Result<Hidraw> {
+    if (hid_init() != 0) {
+        return std::unexpected(std::make_error_code(std::errc::io_error));
+    }
+
+    hid_device* device = nullptr;
+
+    if (!device_name.empty()) {
+        // Open by path (e.g., "hidraw0")
+        device = hid_open_path(device_name.c_str());
+    } else {
+        // Enumerate and find matching interface
+        device = hid_open(vid, pid, nullptr);
+        if (device && iface >= 0) {
+            struct hid_device_info* devs = hid_enumerate(vid, pid);
+            struct hid_device_info* cur = devs;
+            std::string target_path;
+            while (cur) {
+                if (cur->interface_number == iface) {
+                    target_path = cur->path;
+                    break;
+                }
+                cur = cur->next;
+            }
+            hid_free_enumeration(devs);
+
+            if (!target_path.empty()) {
+                hid_close(device);
+                device = hid_open_path(target_path.c_str());
+            }
+        }
+    }
+
+    if (!device) {
+        hid_exit();
+        return std::unexpected(std::make_error_code(std::errc::no_such_device));
+    }
+
+    // Set non-blocking mode for hid_read_timeout
+    hid_set_nonblocking(device, 1);
+
+    return Hidraw(device);
+}
+
+Hidraw::~Hidraw() {
+    if (device_) {
+        hid_close(device_);
+        hid_exit();
+    }
+}
+
+Hidraw::Hidraw(Hidraw&& other) noexcept : device_(other.device_) {
+    other.device_ = nullptr;
+}
+
+auto Hidraw::operator=(Hidraw&& other) noexcept -> Hidraw& {
+    if (this != &other) {
+        if (device_) {
+            hid_close(device_);
+            hid_exit();
+        }
+        device_ = other.device_;
+        other.device_ = nullptr;
+    }
+    return *this;
+}
+
+auto Hidraw::phys() const -> Result<std::string> {
+    // hidapi does not expose the physical device path (e.g. "usb-0000:00:14.0-4/input2").
+    // This means block_redundant_input() in gamepad.cpp will gracefully skip the
+    // redundant input device suppression.
+    return std::unexpected(std::make_error_code(std::errc::function_not_supported));
+}
+
+auto Hidraw::read(std::span<uint8_t> buf) const -> Result<size_t> {
+    if (!device_) {
+        return std::unexpected(std::make_error_code(std::errc::bad_file_descriptor));
+    }
+    int bytes = hid_read_timeout(device_, buf.data(), buf.size(), 10);
+    if (bytes < 0) {
+        return std::unexpected(std::make_error_code(std::errc::resource_unavailable_try_again));
+    }
+    return static_cast<size_t>(bytes);
+}
+
+auto Hidraw::write(std::span<const uint8_t> buf) const -> Result<size_t> {
+    if (!device_) {
+        return std::unexpected(std::make_error_code(std::errc::bad_file_descriptor));
+    }
+    int bytes = hid_write(device_, buf.data(), buf.size());
+    if (bytes < 0) {
+        return std::unexpected(std::make_error_code(std::errc::io_error));
+    }
+    return static_cast<size_t>(bytes);
+}
+
+// parse_report and parse_report_24g are backend-independent (pure data parsing).
+// They are included here to keep them with the Hidraw class.
+
+auto Hidraw::parse_report(std::span<const uint8_t> data) -> std::optional<GamepadState> {
+    constexpr size_t REPORT_24G = 20;
+    constexpr uint8_t SUBTYPE_24G = 0x14;
+
+    if (data.size() == REPORT_24G && data[1] == SUBTYPE_24G) {
+        return parse_report_24g(data);
+    }
+    return std::nullopt;
+}
+
+auto Hidraw::parse_report_24g(std::span<const uint8_t> data) -> std::optional<GamepadState> {
+    constexpr size_t OFF_MISC = 2;
+    constexpr size_t OFF_BTNS = 3;
+    constexpr size_t OFF_LT = 4;
+    constexpr size_t OFF_RT = 5;
+    constexpr size_t OFF_LX = 6;
+    constexpr size_t OFF_LY = 8;
+    constexpr size_t OFF_RX = 10;
+    constexpr size_t OFF_RY = 12;
+    constexpr size_t OFF_EXT1 = 14;
+    constexpr size_t OFF_EXT2 = 15;
+
+    GamepadState state{};
+    const uint8_t misc = data[OFF_MISC];
+    const uint8_t btns = data[OFF_BTNS];
+    state.dpad = DPAD_MAP[misc & DPAD_MASK];
+    state.buttons = static_cast<uint16_t>(
+        (((misc >> 4) & 1) * PAD_START) | (((misc >> 5) & 1) * PAD_SELECT) |
+        (((misc >> 6) & 1) * PAD_L3) | (((misc >> 7) & 1) * PAD_R3) | (((btns >> 0) & 1) * PAD_LB) |
+        (((btns >> 1) & 1) * PAD_RB) | (((btns >> 3) & 1) * PAD_MODE) |
+        (((btns >> 4) & 1) * PAD_A) | (((btns >> 5) & 1) * PAD_B) | (((btns >> 6) & 1) * PAD_X) |
+        (((btns >> 7) & 1) * PAD_Y));
+    state.left_trigger = data[OFF_LT];
+    state.right_trigger = data[OFF_RT];
+    state.left_x = read_s16(&data[OFF_LX]);
+    state.left_y = static_cast<int16_t>(-read_s16(&data[OFF_LY]));
+    state.right_x = read_s16(&data[OFF_RX]);
+    state.right_y = static_cast<int16_t>(-read_s16(&data[OFF_RY]));
+    state.ext_buttons = data[OFF_EXT1];
+    state.ext_buttons2 = data[OFF_EXT2];
+    return state;
+}
+
+} // namespace vader5
+
+#else
+// When not using hidapi, include the original Linux hidraw implementation.
+// This file is handled by src/hidraw.cpp in the default build.
+#endif // VADER5_USE_HIDAPI

--- a/src/hidapi_device.cpp
+++ b/src/hidapi_device.cpp
@@ -45,9 +45,26 @@ auto Hidraw::open(uint16_t vid, uint16_t pid, int iface,
         // Open by path (e.g., "hidraw0")
         device = hid_open_path(device_name.c_str());
     } else {
-        // Enumerate and find matching interface
+        // Try hid_open first (works when kernel driver is not attached)
         device = hid_open(vid, pid, nullptr);
-        if (device && iface >= 0) {
+        if (!device) {
+            // hid_open failed (kernel driver attached). Fallback to path-based open.
+            struct hid_device_info* devs = hid_enumerate(vid, pid);
+            struct hid_device_info* cur = devs;
+            std::string target_path;
+            while (cur) {
+                if (iface < 0 || cur->interface_number == iface) {
+                    target_path = cur->path;
+                    break;
+                }
+                cur = cur->next;
+            }
+            hid_free_enumeration(devs);
+            if (!target_path.empty()) {
+                device = hid_open_path(target_path.c_str());
+            }
+        } else if (iface >= 0) {
+            // hid_open succeeded but wrong interface; reopen by path
             struct hid_device_info* devs = hid_enumerate(vid, pid);
             struct hid_device_info* cur = devs;
             std::string target_path;
@@ -59,7 +76,6 @@ auto Hidraw::open(uint16_t vid, uint16_t pid, int iface,
                 cur = cur->next;
             }
             hid_free_enumeration(devs);
-
             if (!target_path.empty()) {
                 hid_close(device);
                 device = hid_open_path(target_path.c_str());
@@ -83,6 +99,38 @@ Hidraw::~Hidraw() {
         hid_close(device_);
         hid_exit();
     }
+}
+
+auto Hidraw::reconnect(uint16_t vid, uint16_t pid, int iface) -> Result<void> {
+    // Close existing device
+    if (device_) {
+        hid_close(device_);
+        device_ = nullptr;
+    }
+    // Re-open
+    hid_device* device = hid_open(vid, pid, nullptr);
+    if (!device) {
+        struct hid_device_info* devs = hid_enumerate(vid, pid);
+        struct hid_device_info* cur = devs;
+        std::string target_path;
+        while (cur) {
+            if (iface < 0 || cur->interface_number == iface) {
+                target_path = cur->path;
+                break;
+            }
+            cur = cur->next;
+        }
+        hid_free_enumeration(devs);
+        if (!target_path.empty()) {
+            device = hid_open_path(target_path.c_str());
+        }
+    }
+    if (!device) {
+        return std::unexpected(std::make_error_code(std::errc::no_such_device));
+    }
+    hid_set_nonblocking(device, 1);
+    device_ = device;
+    return {};
 }
 
 Hidraw::Hidraw(Hidraw&& other) noexcept : device_(other.device_) {


### PR DESCRIPTION
Add a compile-time option to use hidapi (libusb backend) as an alternative to Linux hidraw for HID device communication.

Motivation
----------
Some Linux environments (notably ChromeOS Crostini, containers, and embedded systems) ship kernels with CONFIG_HIDRAW=n. In these environments, /dev/hidraw* nodes never appear, preventing vader5d from opening the gamepad.

hidapi provides a cross-platform HID abstraction that communicates through /dev/bus/usb/ directly via libusb, completely bypassing the need for hidraw kernel support.

Changes
-------
- New file: src/hidapi_device.cpp (hidapi-based Hidraw implementation)
- Modified: include/vader5/hidraw.hpp (use hid_device* instead of fd)
- Modified: src/daemon/main.cpp (timerfd-based poll loop for hidapi)
- Modified: CMakeLists.txt (new USE_HIDAPI option, links hidapi-libusb)

Compatibility
-------------
- Hidraw class maintains identical public API
- gamepad.cpp, uinput.cpp, config.cpp, mouse.cpp require zero changes
- Existing Linux hidraw users are unaffected (USE_HIDAPI defaults OFF)
- vader5-debug target also supports the hidapi backend

Known limitations in hidapi mode
---------------------------------
- block_redundant_input() is gracefully skipped (hidapi lacks phys path)
- Requires libhidapi-dev and libusb-1.0-0-dev

Build with hidapi:

    cmake -DUSE_HIDAPI=ON ..
    cmake --build . --target vader5d

Tested on ChromeOS Crostini (Linux 6.6, CONFIG_HIDRAW=n) with Flydigi Vader 5 Pro (VID:37d7 PID:2401).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HIDAPI/libusb backend for broader device compatibility and support for additional device interfaces.
* **Bug Fixes**
  * Improved device polling, non-blocking I/O, and reconnect behavior to handle disconnects and reconnections more robustly.
  * Enhanced report decoding to recognize an additional controller report format for more reliable input handling.
* **Chores**
  * Build system updated to allow selecting the HID backend at build time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/flydigi-vader5/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->